### PR TITLE
Add support for relative veracruz directories in VERACRUZ_ROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run: build
 ifndef IAS_TOKEN
 	$(error IAS_TOKEN is not defined)
 endif
-	docker run --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -d -v $(VERACRUZ_ROOT):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --device /dev/isgx --device /dev/mei0 --name $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
+	docker run --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --device /dev/isgx --device /dev/mei0 --name $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
 
 sgx: run
 
@@ -22,17 +22,17 @@ development: build
 ifndef IAS_TOKEN
 	$(error IAS_TOKEN is not defined)
 endif
-	docker run --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -v /lib/modules:/lib/modules -d -v $(VERACRUZ_ROOT):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
+	docker run --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -v /lib/modules:/lib/modules -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
 
 # This macos is used for run test on trustzone either on MacOS or Linux. Please install XQuartz on MacOS or xhost on Linux. 
 .PHONY:
 tz: build
 ifeq ($(OS_NAME),darwin)
 	xhost + $(IP)
-	docker run --privileged -e DISPLAY=$(IP):0 -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(VERACRUZ_ROOT):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
+	docker run --privileged -e DISPLAY=$(IP):0 -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
 else # otherwise linux
 	xhost +local:$(USER)
-	docker run --privileged -e DISPLAY=${DISPLAY} -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(VERACRUZ_ROOT):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
+	docker run --privileged -e DISPLAY=${DISPLAY} -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz -v $(HOME)/.cargo/registry/:/home/$$USER/.cargo/registry/ --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)
 endif
 
 .PHONY:


### PR DESCRIPTION
Allows docker to be invoked like this:

```
make VERACRUZ_ROOT=../veracruz
```