### PR TITLE
Change ifconfig -> ip addr show

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERACRUZ_CONTAINER ?= veracruz
 VERACRUZ_ROOT ?= $(HOME)/git/veracruz
 USER := $(shell id -un)
 UID := $(shell id -u)
-IP := $(shell ifconfig en0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | awk '{print $1}' )
+IP := $(firstword $(shell ip addr show | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | awk '{print $1}' ))
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 
 .PHONY:


### PR DESCRIPTION
The ip command has superseded ifconfig in recent versions of Linux, which means ifconfig is not likely to be found installed on newer machines.

Also en0 is not necessarily the name of the default interface, mine was annoyingly named eno1.

To hopefully help with this I've changed ifconfig -> ip addr and removed the interface name. We already filter out localhost with the following regex, so this ends up with the first non-localhost ip address found by ip addr.