### PR TITLE
This fixes bug in TZ build that fails with perms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ SHELL ["/bin/bash", "-c"]
 # add the arm64 source
 COPY patch/sources.list /etc/apt/ 
 COPY cleanup.sh /cleanup.sh
+USER root
 RUN dpkg --add-architecture arm64
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Sets USER to root in the dockerfile for portion of docker build
for dpkg and apt command section

Signed-off-by: Eric Van Hensbergen <eric.vanhensbergen@arm.com>