### PR TITLE
First cut at splitting up docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,95 +13,26 @@
 #       Each RUN contains a bundle of steps, which reduces the cache.
 ARG TEE
 
-FROM ubuntu:18.04 AS build_sgx
-
-ARG USER
-ARG UID
+FROM veracruz/${TEE}:latest
+ARG USER=root
+ARG UID=0
 ENV DEBIAN_FRONTEND noninteractive
+
+# If you want to use a local cache, you should bind in a local cache directory to /cache
+ENV XARGO_HOME=/cache/xargo \
+    SCCACHE_DIR=/cache/sccache \
+    SCCACHE_CACHE_SIZE=10G \
+    PATH=/cache/cargo/bin:$PATH \
+    RUST_VERSION=1.48.0
+
 # Use bash as the default
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    libcurl4-openssl-dev libprotobuf-dev python cmake git libsqlite3-dev \ 
-    libssl-dev build-essential libtool libclang-dev llvm-dev \
-    wget make curl unzip ca-certificates autoconf automake clang xxd python python-crypto python-pip pkg-config sqlite3; \ 
-    pip install pycryptodome; \
-    apt-get autoremove -y && apt-get clean; \
-    rm -rf /tmp/* /var/tmp/*; \
-# Work around "Unsupported platform - neither systemctl nor initctl is found" raised by sgx psw
-    mkdir /etc/init -p
-
-# Install PSW
-WORKDIR /tmp
-RUN wget https://download.01.org/intel-sgx/linux-2.5/ubuntu18.04-server/libsgx-enclave-common_2.5.101.50123-bionic1_amd64.deb \
-    && dpkg -i libsgx-enclave-common_2.5.101.50123-bionic1_amd64.deb \
-    && rm libsgx-enclave-common_2.5.101.50123-bionic1_amd64.deb  
-
-# Install PSW-dev
-WORKDIR /work
-RUN wget https://download.01.org/intel-sgx/linux-2.5/ubuntu18.04-server/libsgx-enclave-common-dev_2.5.101.50123-bionic1_amd64.deb \
-    && dpkg -i libsgx-enclave-common-dev_2.5.101.50123-bionic1_amd64.deb \
-    && rm libsgx-enclave-common-dev_2.5.101.50123-bionic1_amd64.deb;\ 
-# Install PSW debug symbols
-    wget https://download.01.org/intel-sgx/linux-2.5/ubuntu18.04-server/libsgx-enclave-common-dbgsym_2.5.101.50123-bionic1_amd64.ddeb \
-    && dpkg -i libsgx-enclave-common-dbgsym_2.5.101.50123-bionic1_amd64.ddeb \
-    && rm libsgx-enclave-common-dbgsym_2.5.101.50123-bionic1_amd64.ddeb; \
-
-## fetch and build the SDK
-    wget https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.101.2.bin \
-    && chmod a+x ./sgx_linux_x64_sdk_2.9.101.2.bin \
-    && echo "yes" | ./sgx_linux_x64_sdk_2.9.101.2.bin \
-    && rm sgx_linux_x64_sdk_2.9.101.2.bin \
-    && source /work/sgxsdk/environment \
-    && cat /work/sgxsdk/environment >> /etc/profile; \
 # add a user
-    if [ "$USER" != "root" ] ; then useradd -u $UID -m -p deadbeef -s /bin/bash $USER ; fi; \
-    chown -R $USER /work
-# explictly specify the sgx libraries path and mbed-crypto path
-ENV C_INCLUDE_PATH /work/sgxsdk/include
-
-ARG protobuf_version=3.12.4
-ARG protobuf_dir=/usr/local/protobuf
-ARG protobuf_temp=/tmp/protobuf.zip
-ENV PATH "${protobuf_dir}/bin:${PATH}"
-RUN curl --location https://github.com/protocolbuffers/protobuf/releases/download/v${protobuf_version}/protoc-${protobuf_version}-linux-x86_64.zip > ${protobuf_temp} \
-    && unzip ${protobuf_temp} -d ${protobuf_dir} \
-    && rm ${protobuf_temp} \
-    && chmod --recursive a+rwx ${protobuf_dir}
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.48.0
-
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        gcc \
-        libc6-dev \
-        wget \
-        ; \
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='49c96f3f74be82f4752b8bffcf81961dea5e6e94ce1ccba94435f12e871c3bdb' ;; \
-        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='5a2be2919319e8778698fa9998002d1ec720efe7cb4f6ee4affb006b5e73f1be' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='d93ef6f91dab8299f46eef26a56c2d97c66271cea60bf004f2f088a86a697078' ;; \
-        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e3d0ae3cfce5c6941f74fed61ca83e53d4cd2deb431b906cbd0687f246efede4' ;; \
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-    esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.22.1/${rustArch}/rustup-init"; \
-    wget "$url"; \
-    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
-    rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup component add rust-src; \
-    cargo install xargo --force; \
-    cargo install diesel_cli --no-default-features --features sqlite; \
-    chown -R $USER $RUSTUP_HOME; \
-    chown -R $USER $CARGO_HOME; 
+    RUN \
+        mkdir -p /work; \
+        if [ "$USER" != "root" ] ; then useradd -u $UID -m -p `openssl rand -base64 32` -s /bin/bash $USER ; fi; \
+        chown -R $USER /work;chown -Rf $USER /usr/local/rustup;chown -Rf $USER /usr/local/cargo
 
 # Link the user's toolchain to the global toolchain directory
 USER $USER
@@ -109,212 +40,8 @@ RUN if [ "$USER" != "root" ] ; then mkdir /home/$USER/.rustup; fi;
 WORKDIR /home/$USER/.rustup/
 RUN ln -s /usr/local/rustup/toolchains
 
-#TZ
-FROM build_sgx AS build_tz_base
-
-ARG USER
-ARG UID
-ENV DEBIAN_FRONTEND noninteractive
-# Use bash as the default
-SHELL ["/bin/bash", "-c"]
-
-# add the arm64 source
-COPY patch/sources.list /etc/apt/ 
-COPY cleanup.sh /cleanup.sh
 USER root
-RUN dpkg --add-architecture arm64
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    ack \ 
-            alien \ 
-            android-tools-adb \ 
-            android-tools-fastboot \ 
-            apt-transport-https \ 
-            autoconf \ 
-            automake \ 
-            bc \ 
-            bison \ 
-            build-essential \ 
-            clang \
-            cmake \ 
-            cpio \ 
-            cscope \ 
-            curl \ 
-            device-tree-compiler \ 
-            expect \ 
-            flex \ 
-            ftp-upload \ 
-            g++-multilib \ 
-            gdb \ 
-            gdisk \ 
-            git \ 
-            iasl \ 
-            keychain \
-            kmod \ 
-            libaio-dev \ 
-            libattr1-dev \ 
-            libbluetooth-dev \ 
-            libboost-all-dev \ 
-            libbrlapi-dev \ 
-            libc6-dev \ 
-            libc6-dev-i386 \ 
-            libcap-dev \ 
-            libclang-dev \
-            libcurl4-openssl-dev \ 
-            libfdt-dev \ 
-            libftdi-dev \ 
-            libglib2.0-dev \ 
-            libhidapi-dev \ 
-            libjsoncpp-dev \ 
-            liblog4cpp5-dev \ 
-            libncurses5-dev \ 
-            libpixman-1-dev \ 
-            libprotobuf-c0-dev \ 
-            libprotobuf-dev \ 
-            libsqlite3-dev \ 
-            libsqlite3-dev:arm64 \
-            libssl-dev \ 
-            libsystemd-dev \ 
-            libtool \ 
-            libxml2-dev \ 
-            llvm-dev \
-            make \ 
-            mtools \ 
-            netcat \ 
-            patch \ 
-            pkg-config \ 
-            protobuf-c-compiler \ 
-            protobuf-compiler \ 
-            python \ 
-            python-crypto \ 
-            python-pip \ 
-            python-serial \ 
-            python-wand \ 
-            python3 \
-            python3-pip \ 
-            python3-pyelftools \ 
-            rsync \ 
-            screen \ 
-            sqlite3 \ 
-            sudo \ 
-            systemd \ 
-            systemd-sysv \ 
-            unzip \ 
-            uuid-dev \ 
-            wget \ 
-            xdg-utils \ 
-            xterm \ 
-            xxd \ 
-            xz-utils \ 
-            zlib1g-dev; \
-    apt-get autoremove -y && apt-get clean; \
-    rm -rf /tmp/* /var/tmp/*; \
-    pip install pycryptodome; \
-    pip3 install pycryptodome; \
-    # Use the latest version of repo
-    curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo; \
-    chmod a+x /bin/repo;
-# Add a user
-# Since build_tz_base use build_sgx, the following is commented out. However, we keep the record in case it is needed in the future.
-    #if [ "$USER" != "root" ] ; then useradd -u $UID -m -p deadbeef -s /bin/bash $USER ; fi
-
-# Fetch and install trustzone optee
-WORKDIR /work
-RUN chown -R $USER /work
-USER $USER
-RUN git clone --depth 1 --branch veracruz https://github.com/veracruz-project/rust-optee-trustzone-sdk.git \
-    && cd rust-optee-trustzone-sdk \ 
-    && git submodule update --init \
-# remove unnecessary submodule    
-    && rm -rf rust
-
-# These two patches surprise debug 
-COPY patch/bget.c /work/rust-optee-trustzone-sdk/optee/optee_os/lib/libutils/isoc/
-COPY patch/mempool.c /work/rust-optee-trustzone-sdk/optee/optee_os/lib/libutils/ext/
-
-FROM build_tz_base AS build_optee
-# Install the optee
-WORKDIR /work/rust-optee-trustzone-sdk
-RUN make toolchains; \
-    make -j 12 optee; \
-    source environment;
-
-FROM build_tz_base AS build_qemu 
-USER $USER
-# Install qemu toolchains and openssl
-WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
-USER root
-RUN chown -R $USER /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0
-USER $USER
-RUN mkdir /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0 -p \
-    && cd /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0 \
-    && repo init -q -u https://github.com/veracruz-project/OPTEE-manifest.git -m qemu_v8.xml -b veracruz  \
-# Use the updated repo, as suggested.
-# repo sync, we only sync the current branch with ``-c'' flag.
-    && repo sync -c --no-tags --no-clone-bundle \
-    && cd /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build \
-## Fetch openssl and remove the tar
-    && wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2s.tar.gz \
-    && tar -xvf openssl-1.0.2s.tar.gz \
-    && rm openssl-1.0.2s.tar.gz
-
-# patch optee qemu
-COPY patch/platform_def.h /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/trusted-firmware-a/plat/qemu/include/
-COPY patch/conf.mk /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/core/arch/arm/plat-vexpress/
-COPY patch/core_mmu_lpae.c /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/core/arch/arm/mm/
-COPY patch/build_optee.sh patch/qemu_v8.mk /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/
-COPY patch/environment /work/rust-optee-trustzone-sdk/
-COPY patch/pgt_cache.h /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/core/arch/arm/include/mm/
-
-RUN make -j4 toolchains
-
-FROM build_qemu AS build_tz
-WORKDIR /work/rust-optee-trustzone-sdk/optee
-COPY --from=build_optee /work/rust-optee-trustzone-sdk/optee .
-# Install openssl for compiling trustzone
-WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/openssl-1.0.2s
-RUN ./Configure -fPIC linux-aarch64 \
-    && make -j 12 CC=/work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/toolchains/aarch64/bin/aarch64-linux-gnu-gcc \
-    && mkdir lib/ \
-    && cp libssl.a lib/ \
-    && cp libcrypto.a lib/ 
-
-# Install qemu: set up the environments and then run
-WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/
-RUN mkdir -p out/ \
-    && mkdir -p out/bin \
-    && export ROOT=/work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/ \
-    && export OPENSSL_DIR=/work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/openssl-1.0.2s/ \
-    && export CC=/work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/toolchains/aarch64/bin/aarch64-linux-gnu-gcc \
-    && export PATH=/work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/toolchains/aarch64/bin:$PATH 
-WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
-RUN make QEMU_VIRTFS_ENABLE=y CFG_TEE_RAM_VA_SIZE=0x00300000 -j 12
-
-# set back the work dir 
-WORKDIR /work
-RUN echo "set print array on\nset print pretty on\n\ndefine optee\n\thandle SIGTRAP noprint nostop pass\n\tsymbol-file /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/out/arm/core/tee.elf\n\ttarget remote localhost:1234\nend\ndocument optee\n\tLoads and setup the binary (tee.elf) for OP-TEE and also connects to the QEMU\nremote.\n end" > ~/.gdbinit
-COPY build_optee.sh /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
-COPY run_optee.sh /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
-
-USER $USER
-# set the cross-compiling binary path
-ENV CC_aarch64_unknown_optee_trustzone /work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc
-
-USER root
-RUN chown -R $USER /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/build_optee.sh \
-                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/run_optee.sh \
-                   /work/rust-optee-trustzone-sdk/environment \ 
-                   /work/rust-optee-trustzone-sdk/optee/optee_os/ \
-                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/ \
-                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/ \
-                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/trusted-firmware-a/
 WORKDIR /
-RUN ./cleanup.sh
-
-FROM build_${TEE} as final
-
+RUN chown -R $USER /work
 WORKDIR /work
-COPY --chown=$USER start_aesm.sh .
-# NOTE: The image used in CI should run start_aesm.sh in the gitlab-ci script.
-# Otherwise the gitlab runner may complaint.
-ENTRYPOINT ["bash", "start_aesm.sh"]
+USER $USER

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,74 @@
 VERACRUZ_DOCKER_IMAGE ?= veracruz_image
 VERACRUZ_CONTAINER ?= veracruz
 VERACRUZ_ROOT ?= ..
-USER := $(shell id -un)
-UID := $(shell id -u)
+USER ?= $(shell id -un)
+UID ?= $(shell id -u)
 IP := $(firstword $(shell ip addr show | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | awk '{print $1}' ))
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 
 .PHONY:
 # Assume an linux machine with sgx enable
-run: build
+sgx-run:
 ifndef IAS_TOKEN
 	$(error IAS_TOKEN is not defined)
 endif
-
-	docker run --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --device /dev/isgx --device /dev/mei0 --name $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)_sgx
-
-
-sgx: run
+	docker run --rm --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --device /dev/isgx --device /dev/mei0 --name $(VERACRUZ_CONTAINER)_sgx_$(USER) $(VERACRUZ_DOCKER_IMAGE)_sgx:$(USER) /bin/bash /work/start_aesm.sh
 
 # This is a container for development, which allows compilation.
 .PHONY:
-development: build
+sgx-dev:
 ifndef IAS_TOKEN
 	$(error IAS_TOKEN is not defined)
 endif
+	docker run --rm --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -v /lib/modules:/lib/modules -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --name  $(VERACRUZ_CONTAINER)_sgx_$(USER) $(VERACRUZ_DOCKER_IMAGE)_sgx:$(USER) /bin/bash /work/start_aesm.sh
 
-	docker run --privileged --cap-add=ALL -e IAS_TOKEN=${IAS_TOKEN} -v /lib/modules:/lib/modules -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)_sgx
-
+.PHONY:
+sgx-exec:
+	docker exec -i -t $(VERACRUZ_CONTAINER)_sgx_$(USER) /bin/bash
 
 # This macos is used for run test on trustzone either on MacOS or Linux. Please install XQuartz on MacOS or xhost on Linux. 
 .PHONY:
-tz: build
+tz-run:
 ifeq ($(OS_NAME),darwin)
-	docker run --privileged -e DISPLAY=$(IP):0 -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)_tz
+	docker run --rm --privileged -u $(UID) -e DISPLAY=$(IP):0 -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --name  $(VERACRUZ_CONTAINER)_tz_$(USER) $(VERACRUZ_DOCKER_IMAGE)_tz:$(USER) sleep inf
 else # otherwise linux
-	docker run --privileged -e DISPLAY=${DISPLAY} -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)_tz
+	docker run --rm --privileged -u $(UID) -e DISPLAY=${DISPLAY} -d -v /work/cache:/cache -v /tmp/.X11-unix:/tmp/.X11-unix -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --name  $(VERACRUZ_CONTAINER)_tz_$(USER) $(VERACRUZ_DOCKER_IMAGE)_tz:$(USER) sleep inf
 endif
 
 .PHONY:
-build: Dockerfile
-	DOCKER_BUILDKIT=1 docker build --squash --build-arg USER=$(USER) --build-arg UID=$(UID) --build-arg TEE=$(TEE) -t $(VERACRUZ_DOCKER_IMAGE)_$(TEE) -f $< .
+tz-exec:
+	docker exec -i -t $(VERACRUZ_CONTAINER)_tz_$(USER) /bin/bash
 
 .PHONY:
-ci: Dockerfile.ci
-	DOCKER_BUILDKIT=1 docker build --squash --build-arg USER=root --build-arg UID=0 --build-arg TEE=sgx -t $(VERACRUZ_DOCKER_IMAGE)_sgx -f $<  .
-	DOCKER_BUILDKIT=1 docker build --squash --build-arg USER=root --build-arg UID=0 --build-arg TEE=tz -t $(VERACRUZ_DOCKER_IMAGE)_tz -f $<  .
+build: Dockerfile
+	DOCKER_BUILDKIT=1 docker build --build-arg USER=$(USER) --build-arg UID=$(UID) --build-arg TEE=$(TEE) -t $(VERACRUZ_DOCKER_IMAGE)_$(TEE):$(USER) -f $< .
 
-Dockerfile.ci: Dockerfile
-	sed '/ENTRYPOINT/d' $< | tee $@
+.PHONY:
+base: base/Dockerfile
+	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 -t veracruz/base -f $< .
+
+.PHONY:
+sgx-base: sgx/Dockerfile base
+	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 --build-arg TEE=sgx -t $(VERACRUZ_DOCKER_IMAGE)_sgx:$(USER) -f $< .
+
+.PHONY:
+tz-base: tz/Dockerfile base
+	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 --build-arg TEE=tz -t veracruz/tz-base -f $< .
+
+.PHONY:
+qemu-base: qemu/Dockerfile
+	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 --build-arg TEE=tz -t veracruz/tz -f $< .
+
+.PHONY:
+all-base: base sgx-base tz-base qemu-base
+	echo 'All base docker images re-built from scratch'
+
+.PHONY:
+pull-base:
+	docker pull veracruz/sgx
+	docker pull veracruz/tz
+
+.PHONY:
+ci: Dockerfile
+	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 --build-arg TEE=sgx -t $(VERACRUZ_DOCKER_IMAGE)_sgx -f $<  .
+	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 --build-arg TEE=tz -t $(VERACRUZ_DOCKER_IMAGE)_tz -f $<  .

--- a/README.md
+++ b/README.md
@@ -62,14 +62,23 @@ Note that building the Docker image will take a long time (we appreciate any sug
 
 - ### Build Instructions for SGX
     ```
-    make sgx TEE=sgx IAS_TOKEN=<your Intel Attestation Service token>
+    make build TEE=sgx 
     ```
 - ### Build Instructions for Arm TrustZone
     ```
-    make tz TEE=tz
+    make build TEE=tz
     ```
 
-Once the image build process has finished, there should be a Docker container running called "veracruz". To verify that it's running, run: 
+- ### Starting the veracruz container
+    ```
+    make sgx-run IAS_TOKEN=<your Intel Attestation Service token>
+    ```
+    or (for trustzone):
+    ```
+    make tz-run
+    ```
+
+There should be a Docker container running called "veracruz". To verify that it's running, run: 
     ```
     docker ps
     ```
@@ -87,11 +96,8 @@ You can manually build Veracruz by running:
 ```
 source /work/veracruz/sgx_env.sh
 
-cd /work/veracruz/runtime-manager/
-make
-
-cd /work/veracruz/veracruz-server/
-make
+cd /work/veracruz
+make sgx
 ```
 
 With that, all major sub-components of Veracruz (including the SDK) will be built for SGX.

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,108 @@
+# base docker image for developing and testing Veracruz
+#
+# This builds a common Ubuntu base image with the right pre-installed tools
+# to build custom versions of tools, install rust, and build veracruz itself
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# and copyright information.
+#
+# NOTE: We try to follow the guide in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#       Each RUN contains a bundle of steps, which reduces the cache.
+
+FROM ubuntu:18.04
+
+ARG USER=root
+ARG UID=0
+ENV DEBIAN_FRONTEND noninteractive
+# Use bash as the default
+SHELL ["/bin/bash", "-c"]
+
+# SUPPLY_CHAIN_NOTE: apt-get update means we always get latest, but also doesn't fix versions
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    autoconf \
+    automake \
+    bc \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    git \
+    libaio-dev \ 
+    libbluetooth-dev \ 
+    libcap-dev \     
+    libclang-dev \
+    libcurl4-openssl-dev \
+    libfdt-dev \ 
+    libglib2.0-dev \ 
+    libpixman-1-dev \
+    libprotobuf-dev \
+    libsqlite3-dev \ 
+    libssl-dev \
+    libtool \
+    llvm-dev \
+    make \
+    pkg-config \
+    python \
+    python \
+    python-crypto \
+    python-pip \
+    sqlite3 \ 
+    unzip \
+    uuid-dev \
+    wget \
+    xxd \
+    zlib1g-dev; \
+    pip install pycryptodome; \
+    apt-get autoremove -y && apt-get clean; \
+    rm -rf /tmp/* /var/tmp/*
+
+# add a user
+    RUN \
+        mkdir -p /work; \
+        if [ "$USER" != "root" ] ; then useradd -u $UID -m -p `openssl rand -base64 32` -s /bin/bash $USER ; fi; \
+        chown -R $USER /work
+
+ARG protobuf_version=3.12.4
+ARG protobuf_dir=/usr/local/protobuf
+ARG protobuf_temp=/tmp/protobuf.zip
+ENV PATH "${protobuf_dir}/bin:${PATH}"
+RUN curl --location https://github.com/protocolbuffers/protobuf/releases/download/v${protobuf_version}/protoc-${protobuf_version}-linux-x86_64.zip > ${protobuf_temp} \
+    && unzip ${protobuf_temp} -d ${protobuf_dir} \
+    && rm ${protobuf_temp} \
+    && chmod --recursive a+rwx ${protobuf_dir}
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.48.0 \
+    USER=${USER}
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='49c96f3f74be82f4752b8bffcf81961dea5e6e94ce1ccba94435f12e871c3bdb' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='5a2be2919319e8778698fa9998002d1ec720efe7cb4f6ee4affb006b5e73f1be' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='d93ef6f91dab8299f46eef26a56c2d97c66271cea60bf004f2f088a86a697078' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e3d0ae3cfce5c6941f74fed61ca83e53d4cd2deb431b906cbd0687f246efede4' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.22.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup component add rust-src; \
+    cargo install xargo --force; \
+    cargo install diesel_cli --no-default-features --features sqlite; \
+    chown -R ${USER} $RUSTUP_HOME; \
+    chown -R ${USER} $CARGO_HOME; 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -9,7 +9,13 @@ rm -r linux
 mkdir -p linux/arch/arm64/boot/
 mv /tmp/Image linux/arch/arm64/boot/
 
-mv out-br/images /tmp; \
-rm -r out-br; \
-mkdir -p out-br/; \
+mv out-br/images /tmp
+rm -r out-br
+mkdir -p out-br/
 mv /tmp/images out-br/
+mkdir -p /tmp/out
+cp out/bin/* /tmp/out
+rm -f out/bin/*
+mv /tmp/out/* out/bin/
+
+

--- a/patch/environment
+++ b/patch/environment
@@ -19,3 +19,4 @@ else
   export OPTEE_OS_INCLUDE="$OPTEE_DIR/optee_os/out/arm/export-ta_arm64/include"
   #export CC=$OPTEE_DIR/toolchains/aarch64/bin/aarch64-linux-gnu-gcc
 fi
+export CC_aarch64_unknown_optee_trustzone=/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc

--- a/patch/virt-secure-mem.patch
+++ b/patch/virt-secure-mem.patch
@@ -1,0 +1,13 @@
+diff --git a/hw/arm/virt.c b/hw/arm/virt.c
+index 0a78532018..9e96c2435a 100644
+--- a/hw/arm/virt.c
++++ b/hw/arm/virt.c
+@@ -154,7 +154,7 @@ static const MemMapEntry base_memmap[] = {
+     [VIRT_MMIO] =               { 0x0a000000, 0x00000200 },
+     /* ...repeating for a total of NUM_VIRTIO_TRANSPORTS, each of that size */
+     [VIRT_PLATFORM_BUS] =       { 0x0c000000, 0x02000000 },
+-    [VIRT_SECURE_MEM] =         { 0x0e000000, 0x01000000 },
++    [VIRT_SECURE_MEM] =         { 0x0e000000, 0x02000000 },
+     [VIRT_PCIE_MMIO] =          { 0x10000000, 0x2eff0000 },
+     [VIRT_PCIE_PIO] =           { 0x3eff0000, 0x00010000 },
+     [VIRT_PCIE_ECAM] =          { 0x3f000000, 0x01000000 },

--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -1,0 +1,102 @@
+# docker image for developing and testing Veracruz.
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# and copyright information.
+#
+# NOTE: We try to follow the guide in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#       Each RUN contains a bundle of steps, which reduces the cache.
+
+FROM veracruz/tz-base:latest AS build_qemu 
+ARG USER=root
+ARG UID=0
+ENV DEBIAN_FRONTEND noninteractive
+# Use bash as the default
+SHELL ["/bin/bash", "-c"]
+USER root
+# Install qemu toolchains and openssl
+RUN mkdir /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build -p
+RUN chown -R $USER /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0
+USER $USER
+WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0
+RUN repo init -q -u https://github.com/veracruz-project/OPTEE-manifest.git -m qemu_v8.xml -b veracruz \
+# Use the updated repo, as suggested.
+# repo sync, we only sync the current branch with ``-c'' flag.
+    && repo sync -c --no-tags --no-clone-bundle \
+    && cd /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build \
+## Fetch openssl and remove the tar
+    && wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2s.tar.gz \
+    && tar -xvf openssl-1.0.2s.tar.gz \
+    && rm openssl-1.0.2s.tar.gz
+
+# patch optee qemu
+COPY patch/platform_def.h /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/trusted-firmware-a/plat/qemu/include/
+COPY patch/conf.mk /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/core/arch/arm/plat-vexpress/
+COPY patch/core_mmu_lpae.c /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/core/arch/arm/mm/
+COPY patch/build_optee.sh patch/qemu_v8.mk /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/
+COPY patch/environment /work/rust-optee-trustzone-sdk/
+COPY patch/pgt_cache.h /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/core/arch/arm/include/mm/
+
+WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
+
+WORKDIR /work/rust-optee-trustzone-sdk/optee
+# COPY --from=build_optee /work/rust-optee-trustzone-sdk/optee .
+# Install openssl for compiling trustzone
+WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/openssl-1.0.2s
+RUN ./Configure -fPIC linux-aarch64 \
+    && make -j`nproc` CC=/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc \
+    && mkdir lib/ \
+    && cp libssl.a lib/ \
+    && cp libcrypto.a lib/ 
+
+# Install qemu: set up the environments and then run
+WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/
+RUN mkdir -p out/ \
+    && mkdir -p out/bin \
+    && export ROOT=/work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/ \
+    && export OPENSSL_DIR=/work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/openssl-1.0.2s/ \
+    && export CC=/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc \
+    && export PATH=/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin:$PATH 
+WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/qemu
+COPY patch/virt-secure-mem.patch /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/qemu
+RUN patch -p1 < virt-secure-mem.patch
+WORKDIR /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
+RUN sed -i 's/%TOP_DIR%\/toolchains/\/work\/rust-optee-trustzone-sdk\/optee\/toolchains/g' br-ext/configs/toolchain-aarch*
+RUN sed -i 's/BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_19=y/BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_18=y/g' br-ext/configs/toolchain-aarch64
+RUN make QEMU_VIRTFS_ENABLE=y CFG_TEE_RAM_VA_SIZE=0x00300000 -j`nproc` TOOLCHAIN_ROOT=/work/rust-optee-trustzone-sdk/optee/toolchains all
+
+# set back the work dir 
+WORKDIR /work
+RUN echo "set print array on\nset print pretty on\n\ndefine optee\n\thandle SIGTRAP noprint nostop pass\n\tsymbol-file /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/out/arm/core/tee.elf\n\ttarget remote localhost:1234\nend\ndocument optee\n\tLoads and setup the binary (tee.elf) for OP-TEE and also connects to the QEMU\nremote.\n end" > ~/.gdbinit
+COPY build_optee.sh /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
+COPY run_optee.sh /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build
+
+USER $USER
+# set the cross-compiling binary path
+ENV CC_aarch64_unknown_optee_trustzone /work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc
+
+USER root
+RUN chown -R $USER /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/build_optee.sh \
+                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/run_optee.sh \
+                   /work/rust-optee-trustzone-sdk/environment \ 
+                   /work/rust-optee-trustzone-sdk/optee/optee_os/ \
+                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/optee_os/ \
+                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/ \
+                   /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/trusted-firmware-a/
+WORKDIR /
+COPY cleanup.sh /cleanup.sh
+RUN ./cleanup.sh
+WORKDIR /work
+
+FROM veracruz/tz-base as final
+COPY --from=build_qemu /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/out-br/images/* /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/outbr/images/
+COPY --from=build_qemu /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/out/bin/* /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/out/bin/
+COPY --from=build_qemu /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/qemu/aarch64-softmmu/qemu-* /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/qemu/aarch64-softmmu/
+COPY --from=build_qemu /work/rust-optee-trustzone-sdk/environment /work/rust-optee-trustzone-sdk/environment
+
+WORKDIR /work

--- a/sgx/Dockerfile
+++ b/sgx/Dockerfile
@@ -1,0 +1,55 @@
+# docker image for developing and testing Veracruz on SGX.
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# and copyright information.
+#
+# NOTE: We try to follow the guide in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#       Each RUN contains a bundle of steps, which reduces the cache.
+ARG TEE=sgx
+
+FROM veracruz/base:latest
+
+ARG USER=root
+ARG UID=0
+ENV DEBIAN_FRONTEND noninteractive
+# Use bash as the default
+SHELL ["/bin/bash", "-c"]
+USER root
+RUN mkdir /etc/init -p
+
+# Install PSW
+WORKDIR /tmp
+RUN wget https://download.01.org/intel-sgx/linux-2.5/ubuntu18.04-server/libsgx-enclave-common_2.5.101.50123-bionic1_amd64.deb \
+    && dpkg -i libsgx-enclave-common_2.5.101.50123-bionic1_amd64.deb \
+    && rm libsgx-enclave-common_2.5.101.50123-bionic1_amd64.deb  
+
+# Install PSW-dev
+WORKDIR /work
+RUN wget https://download.01.org/intel-sgx/linux-2.5/ubuntu18.04-server/libsgx-enclave-common-dev_2.5.101.50123-bionic1_amd64.deb \
+    && dpkg -i libsgx-enclave-common-dev_2.5.101.50123-bionic1_amd64.deb \
+    && rm libsgx-enclave-common-dev_2.5.101.50123-bionic1_amd64.deb;\ 
+# Install PSW debug symbols
+    wget https://download.01.org/intel-sgx/linux-2.5/ubuntu18.04-server/libsgx-enclave-common-dbgsym_2.5.101.50123-bionic1_amd64.ddeb \
+    && dpkg -i libsgx-enclave-common-dbgsym_2.5.101.50123-bionic1_amd64.ddeb \
+    && rm libsgx-enclave-common-dbgsym_2.5.101.50123-bionic1_amd64.ddeb; \
+## fetch and build the SDK
+    wget https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.101.2.bin \
+    && chmod a+x ./sgx_linux_x64_sdk_2.9.101.2.bin \
+    && echo "yes" | ./sgx_linux_x64_sdk_2.9.101.2.bin \
+    && rm sgx_linux_x64_sdk_2.9.101.2.bin \
+    && source /work/sgxsdk/environment \
+    && cat /work/sgxsdk/environment >> /etc/profile; \
+# add a user
+    if [ "$USER" != "root" ] ; then useradd -u $UID -m -p `openssl rand -base64 32` -s /bin/bash $USER ; fi; \
+    chown -R $USER /work
+# explictly specify the sgx libraries path and mbed-crypto path
+ENV C_INCLUDE_PATH /work/sgxsdk/include
+
+WORKDIR /work
+COPY --chown=$USER start_aesm.sh .

--- a/tz/Dockerfile
+++ b/tz/Dockerfile
@@ -1,0 +1,122 @@
+# docker image for developing and testing Veracruz on TrustZone
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# and copyright information.
+#
+# NOTE: We try to follow the guide in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#       Each RUN contains a bundle of steps, which reduces the cache.
+ARG TEE=tz
+
+FROM veracruz/base:latest
+
+ARG USER=root
+ARG UID=0
+ENV DEBIAN_FRONTEND noninteractive
+# Use bash as the default
+SHELL ["/bin/bash", "-c"]
+USER root
+# add the arm64 source
+COPY patch/sources.list /etc/apt/ 
+RUN dpkg --add-architecture arm64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+            ack \ 
+            alien \ 
+            android-tools-adb \ 
+            android-tools-fastboot \ 
+            apt-transport-https \ 
+            bison \ 
+            cpio \ 
+            cscope \ 
+            device-tree-compiler \ 
+            expect \ 
+            flex \ 
+            ftp-upload \ 
+            g++-multilib \ 
+            gdb \ 
+            gdisk \ 
+            iasl \ 
+            keychain \
+            kmod \ 
+            libaio-dev \ 
+            libattr1-dev \ 
+            libbluetooth-dev \ 
+            libboost-all-dev \ 
+            libbrlapi-dev \ 
+            libc6-dev \ 
+            libc6-dev-i386 \ 
+            libcap-dev \ 
+            libfdt-dev \ 
+            libftdi-dev \ 
+            libglib2.0-dev \ 
+            libhidapi-dev \ 
+            libjsoncpp-dev \ 
+            liblog4cpp5-dev \ 
+            libncurses5-dev \ 
+            libpixman-1-dev \ 
+            libprotobuf-c0-dev \ 
+            libsqlite3-dev:arm64 \
+            libssl-dev:arm64 \
+            libsystemd-dev \ 
+            libxml2-dev \ 
+            mtools \ 
+            netcat \ 
+            patch \ 
+            pkg-config \ 
+            protobuf-c-compiler \ 
+            protobuf-compiler \ 
+            python-serial \ 
+            python-wand \ 
+            python3 \
+            python3-pip \ 
+            python3-pyelftools \ 
+            rsync \ 
+            screen \ 
+            sudo \ 
+            systemd \ 
+            systemd-sysv \ 
+            uuid-dev \ 
+            xdg-utils \ 
+            xterm \ 
+            xz-utils \ 
+            zlib1g-dev; \
+    apt-get autoremove -y && apt-get clean; \
+    rm -rf /tmp/* /var/tmp/*; \
+    pip3 install pycryptodome; \
+    # Use the latest version of repo
+    curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo; \
+    chmod a+x /bin/repo;
+# Add a user
+RUN if [ "$USER" != "root" ] ; then useradd -u $UID -m -p deadbeef -s /bin/bash $USER ; fi
+
+# Fetch and install trustzone optee
+WORKDIR /work
+RUN chown -R $USER /work
+USER $USER
+RUN git clone --depth 1 --branch veracruz https://github.com/veracruz-project/rust-optee-trustzone-sdk.git \
+    && cd rust-optee-trustzone-sdk \ 
+    && git rm -rf rust \
+    && git submodule update --init; \
+    rm -rf rust-optee-trustzone-sdk/.git; \
+    rm -rf rust-optee-trustzone-sdk/*/.git;
+
+# These two patches surprise debug 
+COPY patch/bget.c /work/rust-optee-trustzone-sdk/optee/optee_os/lib/libutils/isoc/
+COPY patch/mempool.c /work/rust-optee-trustzone-sdk/optee/optee_os/lib/libutils/ext/
+
+# Install the optee
+WORKDIR /work/rust-optee-trustzone-sdk
+RUN make toolchains; \
+    rm -f /work/rust-optee-trustzone-sdk/optee/toolchains/*.tar.xz; \
+    cd optee/toolchains; find . -type f \( -perm -0100 \) -print | xargs -rl strip -s 2> /dev/null;cd ../..;
+
+RUN make -j`nproc` optee; \
+    source environment;
+
+WORKDIR /work


### PR DESCRIPTION
Split main Dockerfile into base, sgx, tz, and qemu.
These may be better off in their own repos so
docker hub builds them on its own.

DRAFT NOTES: TZ is probably not quite right as I'm not inheriting rust basics from SGX and haven't split out qemu (which is biggest offender on size problem).

For rust, may make more sense to add this to base or not at all if we want better control of what rust dependencies are brought in.  For qemu we definitely want to build elsewhere and just copy in binaries.

Signed-off-by: Eric Van Hensbergen <eric.vanhensbergen@arm.com>