### PR TITLE
Changes to enable Nitro enclaves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+aws-nitro-enclaves-cli

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Note that building the Docker image will take a long time (we appreciate any sug
     make build TEE=tz
     ```
 
+- ### Build Instructions for AWS Nitro Enclaves
+    ```
+    make build TEE=nitro
+    ```
+
 - ### Starting the veracruz container
     ```
     make sgx-run IAS_TOKEN=<your Intel Attestation Service token>
@@ -76,6 +81,10 @@ Note that building the Docker image will take a long time (we appreciate any sug
     or (for trustzone):
     ```
     make tz-run
+    ```
+    or (for AWS Nitro Enclaves):
+    ```
+    make nitro-run
     ```
 
 There should be a Docker container running called "veracruz". To verify that it's running, run: 
@@ -155,6 +164,61 @@ make trustzone-veracruz-test
 ```
 
 will execute both of these testsuites.  You, again, should see _7_ and _8_ tests executing and passing, respectively.
+
+## Test Instructions for AWS Nitro Enclaves
+
+Once inside the container, set up your local environment.
+
+You need to configure your AWS credentials by running:
+```
+aws configure
+```
+and entering the appropriate values at the prompt.
+
+Veracruz needs the ability to start another EC2 instance from your initial EC2 instance. The following instructions set up this ability.
+
+You need to get the subnet that your initial EC2 instance is on.
+
+The id of this subnet should be set in the environment varialbe AWS_SUBNET.
+
+You need to create a security group that allows ports 3010, 9090 for private IP addresses within the subnet.
+
+You probably also want to allow port 22 form all IPs to enable you to SSH into the instance (if you think you'll want to)
+
+The name of this security group should be set in the environment variable AWS_SECURITY_GROUP_ID
+
+You also need to set up an AWSK public/private key pair. You need the private key in a file on your initial EC2 instance. The path to this private key should be set in the environment variable AWS_PRIVATE_KEY_FILENAME.
+
+The name of this key pair (as known by AWS) should be set in the environment variable AWS_KEY_NAME.
+
+The AWS region that you are running on should be set in the environment variable AWS_REGION.
+
+To do this, it is recommended to set the variables in a file called nitro.env as follows:
+```bash
+export AWS_KEY_NAME="<VALUE>"
+export AWS_PRIVATE_KEY_FILENAME="<VALUE>"
+export AWS_SUBNET="<VALUE>"
+export AWS_REGION="<VALUE>"
+export AWS_SECURITY_GROUP_ID="<VALUE>"
+```
+Now, to run the tests:
+```
+make trustzone-veracruz-server-test
+```
+
+and
+
+```
+make trustzone-veracruz-test
+```
+
+***IMPORTANT***
+After the tests have run, you should make sure any extra EC2 instances have been
+shut down by running:
+```
+./veracruz-server-test/nitro-ec2-terminate-root.sh
+```
+or you might end up with some surprising AWS bills.
 
 # Cleaning a build
 

--- a/nitro/Dockerfile
+++ b/nitro/Dockerfile
@@ -1,0 +1,64 @@
+# docker image for developing and testing Veracruz on AWS Nitro Enclaves
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# and copyright information.
+#
+# NOTE: We try to follow the guide in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#       Each RUN contains a bundle of steps, which reduces the cache.
+
+FROM veracruz/base:latest
+ARG USER=root
+ARG UID=0
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-setuptools \
+    python3-setuptools \
+    python3 \
+    python3-pip \
+    musl-tools \
+    ca-certificates \
+    curl \
+    lxc \
+    iptables \
+    jq \
+    iproute2
+
+COPY aws-nitro-enclaves-cli/build/nitro_cli/x86_64-unknown-linux-musl/release/nitro-cli /usr/bin/
+
+RUN pip install -U setuptools && \
+    pip install awscli
+
+WORKDIR /work/
+RUN wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1f.tar.gz && \
+    tar zxvf OpenSSL_1_1_1f.tar.gz &&\
+    cd openssl-OpenSSL_1_1_1f && \
+    CC="musl-gcc -fPIE -pie -static -idirafter /usr/include/ -idirafter /usr/include/x86_64-linux-gnu/" ./Configure no-shared no-async --prefix=/work/veracruz-nitro-root-enclave/musl --openssldir=/work/veracruz/nitro-root-enclave/musl/ssl linux-x86_64 -DOPENSSL_NO_SECURE_MEMORY && \
+    make -j 2
+
+ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_LIB_DIR=/work/openssl-OpenSSL_1_1_1f/
+
+ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_INCLUDE_DIR=/work/openssl-OpenSSL_1_1_1f/include/
+
+
+RUN mkdir -p /var/log/nitro_enclaves/
+RUN touch /var/log/nitro_enclaves/nitro_enclaves.log
+
+RUN mkdir -p /usr/share/nitro_enclaves/blobs/
+RUN echo "reboot=k panic=30 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd random.trust_cpu=on" > /usr/share/nitro_enclaves/blobs/cmdline
+
+# Define additional metadata for our image.
+VOLUME /var/lib/docker
+# Nitro
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+	&& unzip awscliv2.zip \
+	&& ./aws/install
+
+RUN rustup target add x86_64-unknown-linux-musl


### PR DESCRIPTION
Added a new docker target nitro. 
Certain things needed to be done inside the make file (like building the AWS nitro-cli tools) instead of the docker file as I would have liked.