### PR TITLE
Add support for IceCap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ UID := $(shell id -u)
 IP := $(firstword $(shell ip addr show | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | awk '{print $1}' ))
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 
+NIX_ROOT ?= ../icecap/nix-root
+
 .PHONY:
 # Assume an linux machine with sgx enable
 run: build
@@ -36,6 +38,11 @@ ifeq ($(OS_NAME),darwin)
 else # otherwise linux
 	docker run --privileged -e DISPLAY=${DISPLAY} -d -v /tmp/.X11-unix:/tmp/.X11-unix -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz --name  $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)_tz
 endif
+
+.PHONY:
+icecap: build
+	mkdir -p $(NIX_ROOT)
+	docker run --privileged -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz -v $(abspath $(NIX_ROOT)):/nix --name $(VERACRUZ_CONTAINER) $(VERACRUZ_DOCKER_IMAGE)_icecap
 
 .PHONY:
 build: Dockerfile

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Veracruz is an adopted project of the Confidential Compute Consortium (CCC).
 
 - Intel SGX
 - Arm TrustZone
+- [IceCap](https://gitlab.com/arm-research/security/icecap/icecap)
 
 ## Requirements
 
@@ -67,6 +68,11 @@ Note that building the Docker image will take a long time (we appreciate any sug
 - ### Build Instructions for Arm TrustZone
     ```
     make tz TEE=tz
+    ```
+
+- ### Build Instructions for IceCap
+    ```
+    make icecap TEE=icecap
     ```
 
 Once the image build process has finished, there should be a Docker container running called "veracruz". To verify that it's running, run: 
@@ -141,6 +147,25 @@ make trustzone-veracruz-test
 ```
 
 will execute both of these testsuites.  You, again, should see _7_ and _8_ tests executing and passing, respectively.
+
+## Test Instructions for IceCap
+
+Once inside the container, execute the following to build, start, and enter a
+QEMU virtual machine running IceCap with the Veracruz test suites:
+
+```sh
+cd /work/veracruz/icecap
+make test-system
+./result/run
+```
+
+Inside the virtual machine's shell, execute the following to run the test
+suites:
+
+```sh
+run_test veracruz-server-test
+run_test veracruz-test
+```
 
 # Cleaning a build
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+set -e
+
+if [ -d /nix -a ! -f /nix/.installed ]; then
+    echo "Installing Nix..."
+    curl -L https://raw.githubusercontent.com/nspin/minimally-invasive-nix-installer/dist/install.sh -o install-nix.sh
+    echo "ebad4f63eb3df7807e249cc3e3883f6d38e28303983f9892dde71f944c0a3558 install-nix.sh" | sha256sum -c -
+    bash install-nix.sh
+    rm install-nix.sh
+    touch /nix/.installed
+fi
+
+LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service
+
+sleep inf

--- a/start_aesm.sh
+++ b/start_aesm.sh
@@ -1,1 +1,0 @@
-LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service; sleep inf


### PR DESCRIPTION
This PR adds support for [IceCap](https://gitlab.com/arm-research/security/icecap/icecap) as an isolation platform for Veracruz.

This PR accompanies https://github.com/veracruz-project/veracruz/pull/149.

At the time of writing, this is a draft, submitted for the purpose of starting a discussion and gathering feedback.