### PR TITLE
Fix some issues in the tz docker and add ci docker

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,27 @@
+# docker image for CI.
+# It combines TZ and SGX.
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# and copyright information.
+#
+# NOTE: We try to follow the guide in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#       Each RUN contains a bundle of steps, which reduces the cache.
+ARG TEE=ci
+
+ARG USER=root
+ARG UID=0
+
+# import the tz image
+FROM veracruz/tz:latest as tz
+
+# use sgx as based and copy in the tz artifact
+FROM veracruz/sgx:latest as final
+COPY --from=tz / /
+
+WORKDIR /work

--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -98,5 +98,6 @@ COPY --from=build_qemu /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/out-br/
 COPY --from=build_qemu /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/out/bin/* /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/out/bin/
 COPY --from=build_qemu /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/qemu/aarch64-softmmu/qemu-* /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/qemu/aarch64-softmmu/
 COPY --from=build_qemu /work/rust-optee-trustzone-sdk/environment /work/rust-optee-trustzone-sdk/environment
+COPY --from=build_qemu /work/rust-optee-trustzone-sdk/optee-qemuv8-3.7.0/build/openssl-1.0.2s/lib/* /usr/lib/aarch64-linux-gnu 
 
 WORKDIR /work


### PR DESCRIPTION
Fix a problem in the tz image and add CI target.

- Copy the libssl.a and libcrypto.a in qemu layer to the appropriate place.
- Add CI dockerfile and CI targets in the makefile.
- Remove the map of `X11` in when running the tz image.