### PR TITLE
Docker support for Nitro-enabled EC2 instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ ci-exec:
 
 .PHONY:
 nitro-container-image/created: nitro-container-image/Dockerfile ../proxy-attestation-server/target/debug/proxy-attestation-server ../veracruz-server/target/debug/veracruz-server ../veracruz-client/target/debug/veracruz-client ../runtime-manager/runtime_manager.eif ../test-collateral/proxy-attestation-server.db ../runtime-manager/PCR0
+	CONTAINERID=$(shell docker create veracruz_image_nitro:$(USER)); \
+        docker cp $$CONTAINERID:/usr/bin/nitro-cli nitro-container-image; \
+        docker rm $$CONTAINERID
 	cp -u ../proxy-attestation-server/target/debug/proxy-attestation-server ../veracruz-server/target/debug/veracruz-server ../veracruz-client/target/debug/veracruz-client ../runtime-manager/runtime_manager.eif ../test-collateral/proxy-attestation-server.db nitro-container-image 
 	cut -c 1-64 < ../runtime-manager/PCR0 > nitro-container-image/hash
 	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 --build-arg TEE=nitro -t veracruz_container_nitro:$(USER)  -f $< .

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,9 @@ ci-exec:
 
 
 .PHONY:
-nitro-container-image/created: nitro-container-image/Dockerfile ../proxy-attestation-server/target/debug/proxy-attestation-server ../veracruz-server/target/debug/veracruz-server ../veracruz-client/target/debug/veracruz-client ../runtime-manager/runtime_manager.eif ../test-collateral/proxy-attestation-server.db 
+nitro-container-image/created: nitro-container-image/Dockerfile ../proxy-attestation-server/target/debug/proxy-attestation-server ../veracruz-server/target/debug/veracruz-server ../veracruz-client/target/debug/veracruz-client ../runtime-manager/runtime_manager.eif ../test-collateral/proxy-attestation-server.db ../runtime-manager/PCR0
 	cp -u ../proxy-attestation-server/target/debug/proxy-attestation-server ../veracruz-server/target/debug/veracruz-server ../veracruz-client/target/debug/veracruz-client ../runtime-manager/runtime_manager.eif ../test-collateral/proxy-attestation-server.db nitro-container-image 
+	cut -c 1-64 < ../runtime-manager/PCR0 > nitro-container-image/hash
 	DOCKER_BUILDKIT=1 docker build --build-arg USER=root --build-arg UID=0 --build-arg TEE=nitro -t veracruz_container_nitro:$(USER)  -f $< .
 	touch nitro-container-image/created
 

--- a/nitro-container-image/Dockerfile
+++ b/nitro-container-image/Dockerfile
@@ -1,0 +1,52 @@
+# docker image for developing and testing Veracruz on AWS Nitro Enclaves
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# and copyright information.
+#
+# NOTE: We try to follow the guide in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#       Each RUN contains a bundle of steps, which reduces the cache.
+
+FROM ubuntu:18.04
+
+ARG USER=root
+ARG UID=0
+ENV DEBIAN_FRONTEND noninteractive
+# Use bash as the default
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl && \
+    apt-get clean 
+#    python-setuptools \
+#    python3-setuptools \
+#    python3 \
+#    python3-pip \
+#    musl-tools \
+#    ca-certificates \
+#    lxc \
+#    iptables \
+#    jq \
+#    iproute2
+#
+COPY aws-nitro-enclaves-cli/build/nitro_cli/x86_64-unknown-linux-musl/release/nitro-cli /usr/bin/
+
+
+COPY nitro-container-image/proxy-attestation-server /work/proxy-attestation-server/proxy-attestation-server
+COPY nitro-container-image/proxy-attestation-server.db /work/proxy-attestation-server/proxy-attestation-server.db
+COPY nitro-container-image/proxy-attestation-server /work/proxy-attestation-server/proxy-attestation-server
+COPY nitro-container-image/veracruz-server /work/veracruz-server/veracruz-server
+COPY nitro-container-image/veracruz-client /work/veracruz-client/veracruz-client
+COPY nitro-container-image/runtime_manager.eif /work/runtime-manager/runtime_manager.eif
+
+RUN mkdir /work/proxy-config-files /work/veracruz-server-policy
+
+WORKDIR /work/veracruz-server
+
+ENV IAS_TOKEN="deadbeefdeadbeefdeadbeefeadbeef"
+

--- a/nitro-container-image/Dockerfile
+++ b/nitro-container-image/Dockerfile
@@ -43,6 +43,7 @@ COPY nitro-container-image/proxy-attestation-server /work/proxy-attestation-serv
 COPY nitro-container-image/veracruz-server /work/veracruz-server/veracruz-server
 COPY nitro-container-image/veracruz-client /work/veracruz-client/veracruz-client
 COPY nitro-container-image/runtime_manager.eif /work/runtime-manager/runtime_manager.eif
++COPY nitro-container-image/hash /work/veracruz-client/hash
 
 RUN mkdir /work/proxy-config-files /work/veracruz-server-policy
 

--- a/nitro-container-image/Dockerfile
+++ b/nitro-container-image/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 #    jq \
 #    iproute2
 #
-COPY aws-nitro-enclaves-cli/build/nitro_cli/x86_64-unknown-linux-musl/release/nitro-cli /usr/bin/
+COPY nitro-container-image/nitro-cli /usr/bin/
 
 
 COPY nitro-container-image/proxy-attestation-server /work/proxy-attestation-server/proxy-attestation-server
@@ -43,7 +43,7 @@ COPY nitro-container-image/proxy-attestation-server /work/proxy-attestation-serv
 COPY nitro-container-image/veracruz-server /work/veracruz-server/veracruz-server
 COPY nitro-container-image/veracruz-client /work/veracruz-client/veracruz-client
 COPY nitro-container-image/runtime_manager.eif /work/runtime-manager/runtime_manager.eif
-+COPY nitro-container-image/hash /work/veracruz-client/hash
+COPY nitro-container-image/hash /work/veracruz-client/hash
 
 RUN mkdir /work/proxy-config-files /work/veracruz-server-policy
 

--- a/nitro-container-image/Dockerfile
+++ b/nitro-container-image/Dockerfile
@@ -38,7 +38,6 @@ COPY nitro-container-image/nitro-cli /usr/bin/
 
 
 COPY nitro-container-image/proxy-attestation-server /work/proxy-attestation-server/proxy-attestation-server
-COPY nitro-container-image/proxy-attestation-server.db /work/proxy-attestation-server/proxy-attestation-server.db
 COPY nitro-container-image/proxy-attestation-server /work/proxy-attestation-server/proxy-attestation-server
 COPY nitro-container-image/veracruz-server /work/veracruz-server/veracruz-server
 COPY nitro-container-image/veracruz-client /work/veracruz-client/veracruz-client


### PR DESCRIPTION
Signed-off-by: Alexandre Peixoto Ferreira <alexandref75@gmail.com>

This PR adds a nitro-container-image/Dockerfile that creates a container that can be used to execute Veracruz in any nitro/docker enable ec2 instance. 
Additional Makefile targets are created that creates the container locally, allow execution of a proxy-attestation-server, Veracruz-server and Veracruz-client each running in a separate container. It also provides an example with certificates/keys/policy/wasm executable. 