### PR TITLE
Updated the README.md. Fix Nitro so non-root users can run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN \
         if getent group nixbld &>/dev/null ; then \
             usermod -a -G nixbld $USER ; \
         fi ; \
+        if getent group ne &>/dev/null ; then \
+            usermod -a -G ne $USER ; \
+        fi ; \
         if [ -d /nix ] ; then \
             chown -R $(USER) /nix ; \
             chmod 0755 /nix ; \

--- a/nitro/Dockerfile
+++ b/nitro/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM veracruz/base:latest
 ARG ARCH=x86_64
+ARG NE_GID=""
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
@@ -66,6 +67,12 @@ RUN mkdir -p /var/log/nitro_enclaves ; \
     chmod a+x /var/log/nitro_enclaves ; \
     mkdir -p /usr/share/nitro_enclaves/blobs/
 COPY aws-nitro-enclaves-cli/blobs/${ARCH}/* /usr/share/nitro_enclaves/blobs
+
+RUN NE_GID=${NE_GID} ; \
+    if [ -z "$NE_GID" ] ; then \
+    else \
+        groupadd -g ${NE_GID} ne ; \
+    fi
 
 # Define additional metadata for our image.
 VOLUME /var/lib/docker


### PR DESCRIPTION
The README.md file was out of date. Updated it by removing obsolete platforms and adding up-to-date instructions for Linux and Nitro using the new workspaces.

Fixed the Dockerfiles so that non-root users can execute nitro tests. Previously, non-root users were not in the `ne` group, which meant they could not access the appropriate parts of the file system.