### PR TITLE
Fixed the nitro build on non-AWS platforms

### DIFF
--- a/nitro/Dockerfile
+++ b/nitro/Dockerfile
@@ -70,6 +70,7 @@ COPY aws-nitro-enclaves-cli/blobs/${ARCH}/* /usr/share/nitro_enclaves/blobs
 
 RUN NE_GID=${NE_GID} ; \
     if [ -z "$NE_GID" ] ; then \
+	echo "No ne group found. Non-root users will be able to build, but not run nitro tests"; \
     else \
         groupadd -g ${NE_GID} ne ; \
     fi


### PR DESCRIPTION
On non-AWS platforms, there is no `ne` group. This caused an empty `then` block in a bash script to be executed, which is not allowed.

Added an `echo` in that block explaining what's happening.