### PR TITLE
Add WABT to docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && \
         libtool \
         llvm-dev \
         make \
+        ninja-build \
         pkg-config \
         procps \
         python \
@@ -105,3 +106,7 @@ RUN set -eux; \
     rm -rf /usr/local/cargo/registry/*/github.com-* ; \
     chmod -R a+rw ${CARGO_HOME} ${RUSTUP_HOME} ; \
     find ${RUSTUP_HOME} ${CARGO_HOME} -type d | xargs -n 1000 chmod a+x
+
+RUN git clone --recursive --depth 1 --branch 1.0.27 https://github.com/WebAssembly/wabt /tmp/wabt \
+    && make -C /tmp/wabt install \
+    && rm -rf /tmp/wabt


### PR DESCRIPTION
The WebAssembly binary toolkit (WABT) has several tools that would help with development on .wasm files

Note: I'm not aware of any apt package for this, so we need to compile from source. The adds ninja as a requirement, though @mathias-arm mentioned we will already need ninja for https://github.com/veracruz-project/veracruz/pull/367.

resolves https://github.com/veracruz-project/veracruz/issues/382

I'm going to look into seeing if we can remove the wasm-checker specific copy of WABT and use this per @dreemkiller's comments