### PR TITLE
Added hadolint to docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -85,6 +85,9 @@ RUN apt-get update && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/* && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
+RUN wget -nv -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64 \
+    && chmod +x /bin/hadolint;
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \


### PR DESCRIPTION
Added latest release version of hadolint as a first step to ease Dockerfile maintenance. Will integrate related CI on veracruz repository. Issue regarding this is [here][issue].

[issue]: https://github.com/veracruz-project/veracruz/issues/50